### PR TITLE
Detect subshells

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/wyne/fasder
 
 go 1.23.0
 
-require github.com/sahilm/fuzzy v0.1.1 // indirect
+require (
+	github.com/sahilm/fuzzy v0.1.1 // indirect
+	golang.org/x/crypto v0.27.0 // indirect
+	golang.org/x/sys v0.25.0 // indirect
+	golang.org/x/term v0.24.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
 github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
 github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
+golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=
+golang.org/x/crypto v0.27.0/go.mod h1:1Xngt8kV6Dvbssa53Ziq6Eqn0HqbZi5Z6R0ZpwQzt70=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.24.0 h1:Mh5cbb+Zk2hqqXNO7S1iTjEphVL+jb8ZWaqh/g+JWkM=
+golang.org/x/term v0.24.0/go.mod h1:lOBK/LVxemqiMij05LGJ0tzNr8xlmwBRJ81PX6wVLH8=

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/wyne/fasder/logger"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Global variable to hold the logger
@@ -33,6 +35,10 @@ func main() {
 
 	files := *filesOnly || (!*filesOnly && !*dirsOnly)
 	dirs := *dirsOnly || (!*filesOnly && !*dirsOnly)
+
+	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+		*list = true
+	}
 
 	LoadFileStore()
 

--- a/main.go
+++ b/main.go
@@ -36,10 +36,6 @@ func main() {
 	files := *filesOnly || (!*filesOnly && !*dirsOnly)
 	dirs := *dirsOnly || (!*filesOnly && !*dirsOnly)
 
-	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
-		*list = true
-	}
-
 	LoadFileStore()
 
 	// Commands
@@ -81,6 +77,13 @@ func main() {
 	matchingEntries := fuzzyFind(entries, searchTerm)
 	filteredEntries := filterEntries(matchingEntries, files, dirs)
 	sortedEntries := sortEntries(filteredEntries, *reverse)
+
+	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+		*list = true
+		bestMatch := []PathEntry{sortedEntries[len(sortedEntries)-1]}
+		displaySortedEntries(bestMatch, *list)
+		return
+	}
 
 	// Execute if necessary
 	if *execCmd != "" {

--- a/main.go
+++ b/main.go
@@ -78,6 +78,9 @@ func main() {
 	filteredEntries := filterEntries(matchingEntries, files, dirs)
 	sortedEntries := sortEntries(filteredEntries, *reverse)
 
+	// If running in a subshell (ex: vim `f zsh`), only
+	// return one result, and auto apply -l list mode
+	// to omit score ranks in output
 	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
 		*list = true
 		bestMatch := []PathEntry{sortedEntries[len(sortedEntries)-1]}


### PR DESCRIPTION
Allow for:

```bash
vim `f .zsh`
```

And automatically apply the `-l` flag, just like `fasd` does.