### PR TITLE
Fix j, jj, vv multiple args

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -16,12 +16,12 @@ func Init(args []string) {
 		switch initializer {
 		case "auto":
 			// TODO: Support other shells
-			zshHook()
+			fmt.Println(ZshHook())
 		case "zsh-hook":
-			zshHook()
+			fmt.Println(ZshHook())
 		case "aliases":
-			aliases()
-			fzfAliases()
+			fmt.Println(Aliases())
+			fmt.Println(fzfAliases())
 		}
 	}
 }

--- a/pty_test.go
+++ b/pty_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/creack/pty"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +26,12 @@ func setupPtyTest(t *testing.T) (func(), []string) {
 		t.Fatal(err)
 	}
 
-	mockData := fmt.Sprintf("%s|1.0|1627849200\n%s|2.0|1627849201", tempFile1.Name(), tempFile2.Name())
+	tempDir1, err := os.MkdirTemp("", "dir1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockData := fmt.Sprintf("%s|1.0|1627849200\n%s|2.0|1627849201\n%s|3.0|1627849202", tempFile1.Name(), tempFile2.Name(), tempDir1)
 
 	tempData, err := os.CreateTemp("", "fasder_test")
 	if err != nil {
@@ -42,9 +49,9 @@ func setupPtyTest(t *testing.T) (func(), []string) {
 		os.Unsetenv("_FASDER_DATA")
 		os.Remove(tempFile1.Name())
 		os.Remove(tempFile2.Name())
+		os.Remove(tempDir1)
 		os.Remove(tempData.Name())
-	}, []string{tempFile1.Name(), tempFile2.Name()}
-
+	}, []string{tempFile1.Name(), tempFile2.Name(), tempDir1}
 }
 
 func TestPty(t *testing.T) {
@@ -56,7 +63,7 @@ func TestPty(t *testing.T) {
 	defer teardown()
 
 	// Prepare the command to run the main program
-	cmd := exec.Command("go", "run", ".") // This runs the current executable
+	cmd := exec.Command("go", "run", ".", "-f") // This runs the current executable
 	t.Logf("Command %s", os.Args[0])
 
 	// Create a pty
@@ -88,15 +95,81 @@ func TestPty(t *testing.T) {
 		"Output mismatch: got '%v', want '%v'",
 		actualOutput,
 		expectedOutput)
-
 }
 
-// readFromPty reads the output from the pty until EOF
+func TestShell(t *testing.T) {
+	if os.Getenv("CI") != "" { // Check if running in a CI environment
+		t.Skip("Skipping PTY test in CI environment")
+	}
+
+	teardown, paths := setupPtyTest(t)
+	defer teardown()
+
+	pathSubStr := paths[2][len(paths[0])-3:]
+
+	// Prepare the command to run the main program
+	allCommands := []string{
+		// ZshHook(),
+		Aliases(),
+		fmt.Sprintf("eval j var %v", pathSubStr),
+		"eval pwd",
+	}
+
+	cmd := exec.Command("zsh", "-l", "-c", strings.Join(allCommands, "\n"))
+	t.Logf("Command %s", strings.Join(cmd.Args, "\n"))
+
+	// Create a pty
+	pty, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("Failed to create pty: %v", err)
+	}
+	defer func() { _ = pty.Close() }() // Close the PTY after use
+
+	// Read output from the pty
+	output, err := readFromPty(pty)
+	if err != nil {
+		t.Fatalf("Failed to read from pty: %v", err)
+	}
+
+	// Wait for the command to finish
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Command finished with error: %v", err)
+	}
+
+	// Normalize line endings for comparison
+	actualOutput := strings.ReplaceAll(output, "\r\n", "\n")
+
+	// Assert the output against the expectation
+	expectedOutput := strings.Join([]string{paths[2]}, "\n")
+	assert.Equal(t,
+		strings.TrimSpace(expectedOutput),
+		strings.TrimSpace(actualOutput),
+		"Output mismatch: got '%v', want '%v'",
+		actualOutput,
+		expectedOutput)
+}
+
+// readFromPty reads the output from the pty until EOF or a timeout
 func readFromPty(pty io.Reader) (string, error) {
 	var buf bytes.Buffer
-	_, err := io.Copy(&buf, pty) // Copy output from pty to buffer
-	if err != nil {
-		return "", err
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second) // Set a timeout
+	defer cancel()
+
+	done := make(chan error)
+
+	go func() {
+		_, err := io.Copy(&buf, pty) // Copy output from pty to buffer
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return "", err
+		}
+	case <-ctx.Done():
+		return "", fmt.Errorf("read from pty timed out")
 	}
+
 	return buf.String(), nil // Return the captured output as a string
 }

--- a/shell.go
+++ b/shell.go
@@ -1,30 +1,22 @@
 package main
 
-import (
-	"fmt"
-)
-
-// zshHook will setup a zshell hook to run and update based on commands
-func zshHook() {
-	fmt.Printf(`
+// ZshHook will setup a zshell hook to run and update based on commands
+func ZshHook() string {
+	return `
     _fasder_preexec() {
       { eval "fasder --proc $(fasder --sanitize $2)"; } >> /dev/null 2>&1
     }
     autoload -Uz add-zsh-hook
     add-zsh-hook preexec _fasder_preexec
-    `)
+    `
 }
 
-func aliases() {
-	fmt.Println(`
+func Aliases() string {
+	return `
     alias a='fasder'
     alias d='fasder -d'
     alias f='fasder -f'
     alias v='fasder -fe $EDITOR'
-    `)
-
-	// j - Jump to best match. If no arguments, jump to previous directory
-	j := `
 	j() {
 	    if [ "$#" -gt 0 ]; then
 	        cd "$(fasder -de 'printf %s' "$@")" || return 1
@@ -33,11 +25,10 @@ func aliases() {
 	    fi
 	}
 	`
-	fmt.Println(j)
 }
 
-func fzfAliases() {
-	fmt.Println(`
+func fzfAliases() string {
+	return `
     jj () {
         local selection
         selection=$(fasder -Rdl "$@" | fzf -1 -0 --no-sort +m --height=10)
@@ -49,9 +40,6 @@ func fzfAliases() {
             return 1
         fi
     }
-    `)
-
-	fmt.Println(`
     vv () {
       local selection
       # Get the selection from fasder and fzf
@@ -73,5 +61,5 @@ func fzfAliases() {
           return 1
       fi
     }
-  `)
+  `
 }

--- a/shell.go
+++ b/shell.go
@@ -27,7 +27,7 @@ func aliases() {
 	j := `
 	j() {
 	    if [ "$#" -gt 0 ]; then
-	        cd "$(fasder -de 'printf %s' "$1")" || return 1
+	        cd "$(fasder -de 'printf %s' "$@")" || return 1
 	    else
 	        cd -
 	    fi
@@ -40,7 +40,7 @@ func fzfAliases() {
 	fmt.Println(`
     jj () {
         local selection
-        selection=$(fasder -Rdl "$1" | fzf -1 -0 --no-sort +m --height=10)
+        selection=$(fasder -Rdl "$@" | fzf -1 -0 --no-sort +m --height=10)
         if [[ -n "$selection" ]]; then
             echo "Selection: $selection"
             cd "$selection" || return 1
@@ -55,7 +55,7 @@ func fzfAliases() {
     vv () {
       local selection
       # Get the selection from fasder and fzf
-      selection=$(fasder -Rfl "$1" | fzf -1 -0 --no-sort +m --height=10)
+      selection=$(fasder -Rfl "$@" | fzf -1 -0 --no-sort +m --height=10)
       
       # Check if a selection was made
       if [[ -n "$selection" ]]; then


### PR DESCRIPTION
Allow multiple arguments for `j`, `jj`, and `vv` commands

Previously:

* `j dir` - Pass
* `j dir sub` - Fail

Now:

* `j dir` - Pass
* `j dir sub` - Pass

Resolves #17