### PR TITLE
Add -D/--delete flag to remove paths from the store

### DIFF
--- a/filestore.go
+++ b/filestore.go
@@ -144,6 +144,28 @@ func writeFileStore(entries []PathEntry) {
 	}
 }
 
+// DeleteFromStore removes entries whose paths match any of the given paths
+func DeleteFromStore(paths []string) {
+	entries, err := readFileStore()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	toDelete := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		toDelete[p] = true
+	}
+
+	filtered := entries[:0]
+	for _, entry := range entries {
+		if !toDelete[entry.Path] {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	writeFileStore(filtered)
+}
+
 // AddToStore an entry to the store
 func AddToStore(path string) {
 	entries, err := readFileStore()

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 
 	// Internal flags
 	add := flag.StringP("add", "A", "", "Internal: Add path to the store")
+	delete := flag.StringArrayP("delete", "D", nil, "Delete path(s) from the store")
 	sanitize := flag.BoolP("sanitize", "", false, "Internal: Sanitize command before processing")
 	proc := flag.BoolP("proc", "", false, "Internal: Process a zsh-hook command")
 
@@ -63,6 +64,11 @@ func main() {
 
 	if *add != "" {
 		AddToStore(*add)
+		return
+	}
+
+	if len(*delete) > 0 {
+		DeleteFromStore(*delete)
 		return
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -107,3 +107,63 @@ func TestSubshellDetection(t *testing.T) {
 	w.Close()
 	checkOutput(t, r, []string{paths[1]})
 }
+
+func TestDeleteExistingPath(t *testing.T) {
+	teardown, r, w, paths := setupTest(t)
+	defer teardown()
+
+	LoadFileStore()
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	os.Args = []string{"cmd", "-D", paths[0], "-l"}
+	main()
+
+	// After delete, list should only contain paths[1]
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	os.Args = []string{"cmd", "-l"}
+	main()
+
+	w.Close()
+	checkOutput(t, r, []string{paths[1]})
+}
+
+func TestDeleteNonExistentPath(t *testing.T) {
+	teardown, r, w, paths := setupTest(t)
+	defer teardown()
+
+	LoadFileStore()
+
+	// Deleting a path not in the store is a no-op
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	os.Args = []string{"cmd", "-D", "/nonexistent/path", "-l"}
+	main()
+
+	// All original entries should still be present
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	os.Args = []string{"cmd", "-l"}
+	main()
+
+	w.Close()
+	checkOutput(t, r, []string{paths[0], paths[1]})
+}
+
+func TestDeleteMultiplePaths(t *testing.T) {
+	teardown, _, w, paths := setupTest(t)
+	defer teardown()
+
+	LoadFileStore()
+
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	os.Args = []string{"cmd", "-D", paths[0], "-D", paths[1]}
+	main()
+
+	w.Close()
+
+	// Store should now be empty
+	entries, err := readFileStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected empty store, got %d entries", len(entries))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `-D`/`--delete` flag (accepts multiple values) to remove one or more entries from `~/.fasder`
- Implements `DeleteFromStore(paths []string)` in `filestore.go` using the same atomic write pattern as the rest of the store
- No-op when a path isn't found (safe to call with stale/typo paths)

Closes #12

## Test plan

- [ ] `fasder -D /some/path` removes the entry from the store
- [ ] `fasder -D /path1 -D /path2` removes multiple entries at once
- [ ] Deleting a path not in the store leaves the store unchanged
- [ ] `go test -run TestDelete ./...` passes

https://claude.ai/code/session_015fMoaAdGN1KxxrVHskgicZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015fMoaAdGN1KxxrVHskgicZ)_